### PR TITLE
Adopt to v1 compatibility layer 

### DIFF
--- a/fluent-plugin-feedly.gemspec
+++ b/fluent-plugin-feedly.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "test-unit", "~> 3.2"
 end

--- a/lib/fluent/plugin/in_feedly.rb
+++ b/lib/fluent/plugin/in_feedly.rb
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+require 'fluent/input'
 
 module Fluent
   class FeedlyInput < Fluent::Input


### PR DESCRIPTION
Otherwise, uninitalize constant `Fluent::Input` error is occurred.