### PR TITLE
Fix rake/bundler vulnerabilities + migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '3.2', '3.3', '3.4' ]
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: ruby
-rvm:
-  - 2.1.3

--- a/fluent-plugin-feedly.gemspec
+++ b/fluent-plugin-feedly.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "fluentd", ">= 0.10.55"
   spec.add_runtime_dependency "feedlr"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "test-unit", "~> 3.2"
 end


### PR DESCRIPTION
## Summary

Resolves the Dependabot `rake` and `bundler` alerts, and migrates CI from the retired Travis to GitHub Actions.

## Security fix

| Dependency | Before | After | CVEs |
|---|---|---|---|
| `rake` | `~> 10.0` | `>= 12.3.3` | CVE-2020-8130 |
| `bundler` | `~> 1.7` | `~> 2.1` | CVE-2016-7954, CVE-2019-3881, CVE-2020-36327, CVE-2021-43809 |

Both are development-only dependencies, so runtime behavior is unchanged. The ranges match the advisories while staying compatible with current toolchains (rake 13.x, bundler 2.6.x).

## CI migration (Travis → GitHub Actions)

`.travis.yml` is replaced with `.github/workflows/ci.yml` running `bundle exec rake test` on Ruby 3.2, 3.3 and 3.4.

## Testing

Green in CI:

```
1 tests, 5 assertions, 0 failures, 0 errors
100% passed
```

> Note: a separate runtime bug in `StateStore` (broken on modern Ruby) is fixed in #4, stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)