### PR TITLE
Fix StateStore runtime errors on modern Ruby

### DIFF
--- a/lib/fluent/plugin/in_feedly.rb
+++ b/lib/fluent/plugin/in_feedly.rb
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require 'fluent/input'
+require 'yaml'
 
 module Fluent
   class FeedlyInput < Fluent::Input
@@ -126,10 +127,20 @@ module Fluent
     class StateStore
       def initialize(path)
         @path = path
-        if File.exists?(@path)
-          @data = YAML.load_file(@path)
-          if @data == false || @data == []
+        if File.exist?(@path)
+          # The state file is written by this plugin and stores symbol-keyed
+          # hashes, so it has to be loaded with Symbol permitted. Psych 4
+          # (Ruby 3.1+) defaults to a safe loader that rejects symbols.
+          @data =
+            begin
+              YAML.load_file(@path, permitted_classes: [Symbol], aliases: true)
+            rescue ArgumentError
+              # Older Psych (Ruby < 3.1) does not accept these keywords.
+              YAML.load_file(@path)
+            end
+          if @data.nil? || @data == false || @data == []
             # this happens if an users created an empty file accidentally
+            # (an empty document loads as nil on Psych 4, false on older Psych)
             @data = {}
           elsif !@data.is_a?(Hash)
             raise "state_file on #{@path.inspect} is invalid"

--- a/test/plugin/test_state_store.rb
+++ b/test/plugin/test_state_store.rb
@@ -1,0 +1,45 @@
+require 'helper'
+require 'tempfile'
+
+class FeedlyStateStoreTest < Test::Unit::TestCase
+  StateStore = Fluent::FeedlyInput::StateStore
+
+  def setup
+    @tmp = Tempfile.new(['feedly_state', '.yml'])
+    @path = @tmp.path
+    @tmp.close
+    @tmp.unlink # start from a non-existent path
+  end
+
+  def teardown
+    File.delete(@path) if File.exist?(@path)
+  end
+
+  def test_missing_file_starts_empty
+    store = StateStore.new(@path)
+    assert_equal({}, store.get('continuation'))
+  end
+
+  def test_round_trip_persists_symbol_keyed_state
+    store = StateStore.new(@path)
+    store.set('continuation', { id: 'cont-123', subscribe_categories_hash: 'hash-abc' })
+    store.update!
+
+    # Re-read from disk: this exercises File.exist? and the Psych 4 safe loader,
+    # which both used to raise on modern Ruby.
+    reloaded = StateStore.new(@path)
+    assert_equal({ id: 'cont-123', subscribe_categories_hash: 'hash-abc' },
+                 reloaded.get('continuation'))
+  end
+
+  def test_empty_file_is_treated_as_empty_state
+    File.open(@path, 'w') { |f| f.write('') }
+    store = StateStore.new(@path)
+    assert_equal({}, store.get('continuation'))
+  end
+
+  def test_invalid_state_file_raises
+    File.open(@path, 'w') { |f| f.write(YAML.dump('not-a-hash')) }
+    assert_raise(RuntimeError) { StateStore.new(@path) }
+  end
+end


### PR DESCRIPTION
## Summary

`StateStore` (the on-disk continuation state used by the input plugin) crashes on current Ruby versions, so the plugin fails as soon as it reads or writes its `state_file`. This PR fixes three independent breakages and adds test coverage.

This is the separate, non-security runtime fix split out from the dependency PR (#3).

## Bugs fixed

| Problem | Fix |
|---|---|
| `File.exists?` was **removed in Ruby 3.2** → `NoMethodError` on every `StateStore.new` | use `File.exist?` |
| Psych 4 (Ruby 3.1+) safe loader **rejects the symbol-keyed hashes** the plugin writes → `Psych::DisallowedClass` on reload | load with `permitted_classes: [Symbol]` (with a fallback for older Psych) |
| An empty state file now loads as `nil` (was `false`) → misdetected as "invalid" and raised | treat `nil` as empty state, matching the original intent |

`require 'yaml'` is now performed at load time so `StateStore` is self-contained.

## Testing

Added `test/plugin/test_state_store.rb` covering missing-file, round-trip persistence, empty-file and invalid-file paths.

```
5 tests, 9 assertions, 0 failures, 0 errors, 0 pendings
100% passed
```

## Note on base branch

This PR is based on `fix/rake-bundler-security` (#3) so it picks up the modern toolchain and the new GitHub Actions CI. GitHub will automatically retarget it to `master` once #3 is merged. Please merge #3 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)