### PR TITLE
Add GitHub Actions CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fluent-plugin-feedly
 
+[![Test](https://github.com/y-ken/fluent-plugin-feedly/actions/workflows/ci.yml/badge.svg)](https://github.com/y-ken/fluent-plugin-feedly/actions/workflows/ci.yml)
+
 ## Overview
 
 Fluentd input plugin to fetch RSS/ATOM feed via feedly Cloud API.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI status badge to the top of the README, now that CI runs on GitHub Actions (the workflow added in #3).

```markdown
[![Test](https://github.com/y-ken/fluent-plugin-feedly/actions/workflows/ci.yml/badge.svg)](https://github.com/y-ken/fluent-plugin-feedly/actions/workflows/ci.yml)
```

This repo previously had no build badge, so this is a pure addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)